### PR TITLE
Fix "unknown command 'AUTH'"

### DIFF
--- a/redis_sentinel_url.py
+++ b/redis_sentinel_url.py
@@ -100,7 +100,7 @@ def parse_sentinel_url(url, sentinel_options=None, client_options=None):
         url_options.update(client_options)
 
     if password is not None:
-        sentinel_url_options['password'] = password
+        url_options['password'] = password
 
     for name, value in iteritems(urlparse.parse_qs(url.query)):
         if name in global_option_types:

--- a/test_redis_sentinel_url.py
+++ b/test_redis_sentinel_url.py
@@ -103,7 +103,8 @@ class TestUrlParsing(TestCase):
 
     def test_with_password(self):
         parsed = parse_sentinel_url('redis+sentinel://:thesecret@hostname:7000')
-        self.assertEquals(parsed.sentinel_options, {'password': 'thesecret'})
+        self.assertEquals(parsed.sentinel_options, {})
+        self.assertEquals(parsed.client_options['password'], 'thesecret')
 
 
 class FakeRedis(MagicMock):
@@ -223,4 +224,3 @@ class TestConnecting(TestCase):
         with self.assertRaisesRegexp(ValueError, r'Unsupported redis URL scheme: redis\+something'):
             connect('redis+something://hostname:7001/myslave/3?slave=true', client_class=FakeRedis,
                     sentinel_class=FakeSentinel, client_options={'decode_responses': True})
-


### PR DESCRIPTION
I got the following error when I tried to connect to Redis Sentinel with password:

```
>>> import redis_sentinel_url
>>> s, c = redis_sentinel_url.connect('redis+sentinel://:secret@sentinel1:26379,sentinel2:26379,sentinel3:26379')
>>> m = s.master_for('mymaster')
>>> m.info()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/site-packages/redis/client.py", line 665, in info
    return self.execute_command('INFO')
  File "/usr/local/lib/python3.5/site-packages/redis/client.py", line 572, in execute_command
    connection.send_command(*args)
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 563, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 538, in send_packed_command
    self.connect()
  File "/usr/local/lib/python3.5/site-packages/redis/sentinel.py", line 44, in connect
    self.connect_to(self.connection_pool.get_master_address())
  File "/usr/local/lib/python3.5/site-packages/redis/sentinel.py", line 100, in get_master_address
    self.service_name)
  File "/usr/local/lib/python3.5/site-packages/redis/sentinel.py", line 213, in discover_master
    masters = sentinel.sentinel_masters()
  File "/usr/local/lib/python3.5/site-packages/redis/client.py", line 707, in sentinel_masters
    return self.execute_command('SENTINEL MASTERS')
  File "/usr/local/lib/python3.5/site-packages/redis/client.py", line 572, in execute_command
    connection.send_command(*args)
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 563, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 538, in send_packed_command
    self.connect()
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 446, in connect
    self.on_connect()
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 514, in on_connect
    if nativestr(self.read_response()) != 'OK':
  File "/usr/local/lib/python3.5/site-packages/redis/connection.py", line 582, in read_response
    raise response
redis.exceptions.ResponseError: unknown command 'AUTH'
```

This PR should fix the issue.

Ref: andymccurdy/redis-py#483