### PR TITLE
Handle URL-encoded passwords and service names.

### DIFF
--- a/redis_sentinel_url.py
+++ b/redis_sentinel_url.py
@@ -13,11 +13,16 @@
 # limitations under the License.
 
 from collections import namedtuple
-import urllib
 try:
     import urllib.parse as urlparse
 except ImportError:  # pragma: no cover
     import urlparse
+
+try:
+    from urllib.parse import unquote
+except ImportError:  # pragma: no cover
+    from urllib import unquote
+
 import redis
 import redis.sentinel  # requires redis-py 2.9.0+
 import sys
@@ -75,7 +80,7 @@ def parse_sentinel_url(url, sentinel_options=None, client_options=None):
         hostspec = url.netloc
 
     if auth and ':' in auth:
-        password = urllib.unquote(auth.split(':', 1)[1])
+        password = unquote(auth.split(':', 1)[1])
     else:
         password = None
 
@@ -137,7 +142,7 @@ def parse_sentinel_url(url, sentinel_options=None, client_options=None):
     if 'service' in url_options:
         service_name = url_options.pop('service')
     elif len(path_parts) >= 1:
-        service_name = urllib.unquote(path_parts[0])
+        service_name = unquote(path_parts[0])
     else:
         service_name = None
 

--- a/redis_sentinel_url.py
+++ b/redis_sentinel_url.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import namedtuple
+import urllib
 try:
     import urllib.parse as urlparse
 except ImportError:  # pragma: no cover
@@ -74,7 +75,7 @@ def parse_sentinel_url(url, sentinel_options=None, client_options=None):
         hostspec = url.netloc
 
     if auth and ':' in auth:
-        _, password = auth.split(':', 1)
+        password = urllib.unquote(auth.split(':', 1)[1])
     else:
         password = None
 
@@ -136,7 +137,7 @@ def parse_sentinel_url(url, sentinel_options=None, client_options=None):
     if 'service' in url_options:
         service_name = url_options.pop('service')
     elif len(path_parts) >= 1:
-        service_name = path_parts[0]
+        service_name = urllib.unquote(path_parts[0])
     else:
         service_name = None
 

--- a/test_redis_sentinel_url.py
+++ b/test_redis_sentinel_url.py
@@ -106,6 +106,10 @@ class TestUrlParsing(TestCase):
         self.assertEquals(parsed.sentinel_options, {})
         self.assertEquals(parsed.client_options['password'], 'thesecret')
 
+    def test_with_url_encoding(self):
+        parsed = parse_sentinel_url('redis+sentinel://:%20%20@hostname:7000/%2F%2Fmydb%2F%2F/0')
+        self.assertEquals(parsed.client_options['password'], '  ')
+        self.assertEqual(parsed.default_client, DefaultClient('master', '//mydb//'))
 
 class FakeRedis(MagicMock):
     def __init__(self, host='localhost', port=6379,

--- a/test_redis_sentinel_url.py
+++ b/test_redis_sentinel_url.py
@@ -111,6 +111,7 @@ class TestUrlParsing(TestCase):
         self.assertEquals(parsed.client_options['password'], '  ')
         self.assertEqual(parsed.default_client, DefaultClient('master', '//mydb//'))
 
+
 class FakeRedis(MagicMock):
     def __init__(self, host='localhost', port=6379,
                  db=0, password=None, socket_timeout=None,


### PR DESCRIPTION
This is required to support non URL safe passwords or service names,
which should be url encoded in this case.